### PR TITLE
Fix category modal title color in dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@ input, select, textarea{width:100%; padding:12px 14px; border-radius:14px; borde
     html.dark .card .title{color:#000}
     html.dark .linkTitle{background:#ccc;color:#000}
     html.dark #settingsForm .btn{background:#ccc;color:#000}
+    html.dark #categoryTitle{color:#000}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- ensure category modal title text uses black in dark theme for readability

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a753bad0ac8331a8a5dbdb5bf7c05b